### PR TITLE
Expose initial shared library load failure

### DIFF
--- a/sciter-x-api.c
+++ b/sciter-x-api.c
@@ -127,6 +127,7 @@
 
             void* lib_sciter_handle = dlopen(SCITER_DLL_NAME, RTLD_LOCAL|RTLD_LAZY);
             if( !lib_sciter_handle ) {
+                fprintf(stderr, "[%s] Unable to load library: %s\n", __FILE__, dlerror());
                 const char* lookup_paths[] =
                 {
                     "/" SCITER_DLL_NAME,


### PR DESCRIPTION
Otherwise subsequent dlerror() call masks root cause of the failure.
